### PR TITLE
ArgumentNullException expects param first

### DIFF
--- a/SmsSender.cs
+++ b/SmsSender.cs
@@ -64,7 +64,7 @@ namespace NetSmsSender
 
             if (string.IsNullOrWhiteSpace(text))
             {
-                throw new ArgumentNullException("A text must be specified.", "text");
+                throw new ArgumentNullException("text", "A text must be specified.");
             }
 
             // Port creation.


### PR DESCRIPTION
Message is specified as param and vice versa.
